### PR TITLE
Extend attributes to Rows and Columns

### DIFF
--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -83,7 +83,7 @@ class BBCustomAttributes
      *
      * @return array
      */
-    public function filterAdvancedModule($form, $id)
+    public function filterAdvancedTabAttr($form, $id)
     {
         if ('module_advanced' === $id) {
             $form['sections']['css_selectors']['fields']['custom_attributes'] = [

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -22,9 +22,9 @@ class BBCustomAttributes
     {
         add_action('plugins_loaded', [$this, 'registerForm']);
         add_filter('fl_builder_register_settings_form', [$this, 'filterAdvancedTabAttr'], 10, 2);
-        add_filter('fl_builder_module_attributes', [$this, 'filterElementAttributes'], 10, 2);
-        add_filter('fl_builder_column_attributes', [$this, 'filterElementAttributes'], 10, 2);
-        add_filter('fl_builder_row_attributes', [$this, 'filterElementAttributes'], 10, 2);
+        add_filter('fl_builder_module_attributes', [$this, 'filterAttributes'], 10, 2);
+        add_filter('fl_builder_column_attributes', [$this, 'filterAttributes'], 10, 2);
+        add_filter('fl_builder_row_attributes', [$this, 'filterAttributes'], 10, 2);
     }
 
     /**
@@ -40,7 +40,7 @@ class BBCustomAttributes
             'title' => __('Custom Attributes'),
             'tabs'  => [
                 'attributes' => [
-                    'title'    => __('Attributes'),
+                    'title'    => __('Attribute'),
                     'sections' => [
                         'general' => [
                             'title'  => '',
@@ -89,7 +89,7 @@ class BBCustomAttributes
             $form['sections']['css_selectors']['fields']['custom_attributes'] = [
                 'type'         => 'form',
                 'form'         => 'custom_attributes',
-                'label'        => __('Attributes'),
+                'label'        => __('Attribute'),
                 'help'         => __('Adds custom attributes to the module'),
                 'multiple'     => true,
                 'preview_text' => 'key'
@@ -100,7 +100,7 @@ class BBCustomAttributes
             $form['tabs']['advanced']['sections']['css_selectors']['fields']['custom_attributes'] = [
                 'type'         => 'form',
                 'form'         => 'custom_attributes',
-                'label'        => __('Attributes'),
+                'label'        => __('Attribute'),
                 'help'         => __('Adds custom attributes to the column'),
                 'multiple'     => true,
                 'preview_text' => 'key'
@@ -111,7 +111,7 @@ class BBCustomAttributes
             $form['tabs']['advanced']['sections']['css_selectors']['fields']['custom_attributes'] = [
                 'type'         => 'form',
                 'form'         => 'custom_attributes',
-                'label'        => __('Attributes'),
+                'label'        => __('Attribute'),
                 'help'         => __('Adds custom attributes to the row'),
                 'multiple'     => true,
                 'preview_text' => 'key'
@@ -122,14 +122,14 @@ class BBCustomAttributes
     }
 
     /**
-     * Adds the custom attributes to the element being rendered
+     * Adds the custom attributes to the row/column/module being rendered
      *
      * @param array    $attributes
      * @param object   $element
      *
      * @return array
      */
-    public function filterElementAttributes($attributes, $element)
+    public function filterAttributes($attributes, $element)
     {
         if (isset($element->settings->custom_attributes)) {
 		    foreach ($element->settings->custom_attributes as $attribute) {

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -2,8 +2,8 @@
 /**
  * Plugin Name: Beaver Builder Custom Attributes
  * Plugin URI: https://github.com/JasonTheAdams/BBCustomAttributes
- * Description: Adds the ability to set custom attributes for all modules, columns, and rows
- * Version: 1.0.0
+ * Description: Adds the ability to set custom attributes for modules, columns, and rows
+ * Version: 1.1.0
  * Author: Jason Adams
  * Author URI: https://github.com/jasontheadams
  * Requires PHP: 5.6
@@ -22,9 +22,9 @@ class BBCustomAttributes
     {
         add_action('plugins_loaded', [$this, 'registerForm']);
         add_filter('fl_builder_register_settings_form', [$this, 'filterAdvancedTabAttr'], 10, 2);
-        add_filter('fl_builder_module_attributes', [$this, 'filterModuleAttributes'], 10, 2);
-        add_filter('fl_builder_column_attributes', [$this, 'filterColAttributes'], 10, 2);
-		add_filter('fl_builder_row_attributes', [$this, 'filterRowAttributes'], 10, 2);
+        add_filter('fl_builder_module_attributes', [$this, 'filterElementAttributes'], 10, 2);
+        add_filter('fl_builder_column_attributes', [$this, 'filterElementAttributes'], 10, 2);
+        add_filter('fl_builder_row_attributes', [$this, 'filterElementAttributes'], 10, 2);
     }
 
     /**
@@ -107,7 +107,7 @@ class BBCustomAttributes
             ];
         }
 		
-		if('row' === $id ) {
+        if('row' === $id ) {
             $form['tabs']['advanced']['sections']['css_selectors']['fields']['custom_attributes'] = [
                 'type'         => 'form',
                 'form'         => 'custom_attributes',
@@ -122,55 +122,19 @@ class BBCustomAttributes
     }
 
     /**
-     * Adds the custom attributes to the module being rendered
+     * Adds the custom attributes to the element being rendered
      *
-     * @param array            $attributes
-     * @param \FLBuilderModule $module
+     * @param array    $attributes
+     * @param object   $element
      *
      * @return array
      */
-    public function filterModuleAttributes($attributes, $module)
+    public function filterElementAttributes($attributes, $element)
     {
-        if (isset($module->settings->custom_attributes)) {
-            foreach ($module->settings->custom_attributes as $attribute) {
-                $key = esc_attr($attribute->key);
-                if ('yes' === $attribute->override || ! isset($attributes[$key])) {
-                    $value = do_shortcode(esc_attr($attribute->value));
-                    $attributes[$key] = $value;
-                }
-            }
-        }
-
-        return $attributes;
-    }
-    
-    /**
-	 * Adds the custom attributes to the column being rendered
-	 */
-    public function filterColAttributes($attributes, $col)
-    {
-        if (isset($col->settings->custom_attributes)) {
-            foreach ($col->settings->custom_attributes as $attribute) {
-                $key = esc_attr($attribute->key);
-                if ('yes' === $attribute->override || ! isset($attributes[$key])) {
-                    $value = do_shortcode(esc_attr($attribute->value));
-                    $attributes[$key] = $value;
-                }
-            }
-        }
-
-        return $attributes;
-    }
-	
-	/**
-	 * Adds the custom attributes to the row being rendered
-	 */
-    public function filterRowAttributes($attributes, $row)
-    {
-        if (isset($row->settings->custom_attributes)) {
-            foreach ($row->settings->custom_attributes as $attribute) {
-                $key = esc_attr($attribute->key);
-                if ('yes' === $attribute->override || ! isset($attributes[$key])) {
+        if (isset($element->settings->custom_attributes)) {
+		    foreach ($element->settings->custom_attributes as $attribute) {
+		        $key = esc_attr($attribute->key);
+		        if ('yes' === $attribute->override || !isset($attributes[$key])) {
                     $value = do_shortcode(esc_attr($attribute->value));
                     $attributes[$key] = $value;
                 }

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -111,7 +111,8 @@ class BBCustomAttributes
             foreach ($module->settings->custom_attributes as $attribute) {
                 $key = esc_attr($attribute->key);
                 if ('yes' === $attribute->override || ! isset($attributes[$key])) {
-                    $attributes[$key] = esc_attr($attribute->value);
+                    $value = do_shortcode(esc_attr($attribute->value));
+                    $attributes[$key] = $value;
                 }
             }
         }

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -21,8 +21,10 @@ class BBCustomAttributes
     public function load()
     {
         add_action('plugins_loaded', [$this, 'registerForm']);
-        add_filter('fl_builder_register_settings_form', [$this, 'filterAdvancedModule'], 10, 2);
-        add_filter('fl_builder_module_attributes', [$this, 'filterAttributes'], 10, 2);
+        add_filter('fl_builder_register_settings_form', [$this, 'filterAdvancedTabAttr'], 10, 2);
+        add_filter('fl_builder_module_attributes', [$this, 'filterModuleAttributes'], 10, 2);
+        add_filter('fl_builder_column_attributes', [$this, 'filterColAttributes'], 10, 2);
+		add_filter('fl_builder_row_attributes', [$this, 'filterRowAttributes'], 10, 2);
     }
 
     /**
@@ -93,6 +95,28 @@ class BBCustomAttributes
                 'preview_text' => 'key'
             ];
         }
+        
+        if('col' === $id ) {
+            $form['tabs']['advanced']['sections']['css_selectors']['fields']['custom_attributes'] = [
+                'type'         => 'form',
+                'form'         => 'custom_attributes',
+                'label'        => __('Attributes'),
+                'help'         => __('Adds custom attributes to the column'),
+                'multiple'     => true,
+                'preview_text' => 'key'
+            ];
+        }
+		
+		if('row' === $id ) {
+            $form['tabs']['advanced']['sections']['css_selectors']['fields']['custom_attributes'] = [
+                'type'         => 'form',
+                'form'         => 'custom_attributes',
+                'label'        => __('Attributes'),
+                'help'         => __('Adds custom attributes to the row'),
+                'multiple'     => true,
+                'preview_text' => 'key'
+            ];
+        }
 
         return $form;
     }
@@ -105,10 +129,46 @@ class BBCustomAttributes
      *
      * @return array
      */
-    public function filterAttributes($attributes, $module)
+    public function filterModuleAttributes($attributes, $module)
     {
         if (isset($module->settings->custom_attributes)) {
             foreach ($module->settings->custom_attributes as $attribute) {
+                $key = esc_attr($attribute->key);
+                if ('yes' === $attribute->override || ! isset($attributes[$key])) {
+                    $value = do_shortcode(esc_attr($attribute->value));
+                    $attributes[$key] = $value;
+                }
+            }
+        }
+
+        return $attributes;
+    }
+    
+    /**
+	 * Adds the custom attributes to the column being rendered
+	 */
+    public function filterColAttributes($attributes, $col)
+    {
+        if (isset($col->settings->custom_attributes)) {
+            foreach ($col->settings->custom_attributes as $attribute) {
+                $key = esc_attr($attribute->key);
+                if ('yes' === $attribute->override || ! isset($attributes[$key])) {
+                    $value = do_shortcode(esc_attr($attribute->value));
+                    $attributes[$key] = $value;
+                }
+            }
+        }
+
+        return $attributes;
+    }
+	
+	/**
+	 * Adds the custom attributes to the row being rendered
+	 */
+    public function filterRowAttributes($attributes, $row)
+    {
+        if (isset($row->settings->custom_attributes)) {
+            foreach ($row->settings->custom_attributes as $attribute) {
                 $key = esc_attr($attribute->key);
                 if ('yes' === $attribute->override || ! isset($attributes[$key])) {
                     $value = do_shortcode(esc_attr($attribute->value));

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -132,9 +132,9 @@ class BBCustomAttributes
     public function filterAttributes($attributes, $element)
     {
         if (isset($element->settings->custom_attributes)) {
-		    foreach ($element->settings->custom_attributes as $attribute) {
-		        $key = esc_attr($attribute->key);
-		        if ('yes' === $attribute->override || !isset($attributes[$key])) {
+            foreach ($element->settings->custom_attributes as $attribute) {
+                $key = esc_attr($attribute->key);
+                if ('yes' === $attribute->override || !isset($attributes[$key])) {
                     $value = do_shortcode(esc_attr($attribute->value));
                     $attributes[$key] = $value;
                 }

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Beaver Builder Custom Attributes
  * Plugin URI: https://github.com/JasonTheAdams/BBCustomAttributes
- * Description: Adds the ability to set custom attributes for all modules
+ * Description: Adds the ability to set custom attributes for all modules, columns, and rows
  * Version: 1.0.0
  * Author: Jason Adams
  * Author URI: https://github.com/jasontheadams


### PR DESCRIPTION
We can use fl_builder_column_attributes and fl_builder_row_attributes to extend this functionality to Beaver Builder rows and columns.