### PR TITLE
Add preview_text of the attr 'key' to the form

### DIFF
--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Beaver Builder Custom Attributes
  * Plugin URI: https://github.com/JasonTheAdams/BBCustomAttributes
  * Description: Adds the ability to set custom attributes for modules, columns, and rows
- * Version: 1.1.0
+ * Version: 1.2.0
  * Author: Jason Adams
  * Author URI: https://github.com/jasontheadams
  * Requires PHP: 5.6
@@ -67,7 +67,8 @@ class BBCustomAttributes
                                         'yes' => __('Yes')
                                     ]
                                 ]
-                            ]
+                            ],
+                            'preview_text' => 'key'
                         ]
                     ]
                 ]


### PR DESCRIPTION
Adding `preview_text` of the attr 'key' to the form lets the user see which attrs have been set without having to click into each one

![Screenshot 2024-01-15 at 09 59 50](https://github.com/JasonTheAdams/BBCustomAttributes/assets/19413506/a6d27467-14be-4d36-bcf4-61bdf39de331)
