### PR TITLE
Fix/missing custom attrs event

### DIFF
--- a/assets/js/bb-custom-attributes.js
+++ b/assets/js/bb-custom-attributes.js
@@ -17,4 +17,11 @@ document.addEventListener('DOMContentLoaded', function() {
         // Remove the data-custom-attributes attribute after processing
         element.removeAttribute('data-custom-attributes');
     });
+    
+    // Set the global flag to indicate processing is complete
+    window.customAttrsProcessingComplete = true;
+    
+    // Dispatch the custom event to notify other scripts
+    const event = new CustomEvent('customAttrsProcessed');
+    document.dispatchEvent(event);
 });

--- a/bb-custom-attributes.php
+++ b/bb-custom-attributes.php
@@ -3,7 +3,7 @@
  * Plugin Name: Beaver Builder Custom Attributes
  * Plugin URI: https://github.com/JasonTheAdams/BBCustomAttributes
  * Description: Adds the ability to set custom attributes for modules, columns, and rows
- * Version: 1.3
+ * Version: 1.3.1
  * Author: Jason Adams
  * Author URI: https://github.com/jasontheadams
  * Requires PHP: 5.6
@@ -14,7 +14,7 @@
 namespace JasonTheAdams\BBCustomAttributes;
 
 // Define plugin version
-define( 'BBCUSTOMATTRIBUTES_VERSION', '1.3' );
+define( 'BBCUSTOMATTRIBUTES_VERSION', '1.3.1' );
 
 // Include core plugin functionality
 include_once plugin_dir_path( __FILE__ ) . 'includes/BBCustomAttributes.php';


### PR DESCRIPTION
Adds the missing `customAttrsProcessed` event dispatch and `window.customAttrsProcessingComplete` flag that are documented in the README but not implemented in the JavaScript.

## Changes
- Added window.customAttrsProcessingComplete = true after attribute processing
- Added customAttrsProcessed event dispatch to notify other scripts

Fixes #15 